### PR TITLE
fix : reject promises instead of resolving to false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ export class StoicIdentity extends SignIdentity {
       if (host) _stoicOrigin = host;
       _stoicLogin(_stoicOrigin).then(data => {
         resolve(new StoicIdentity(Principal.fromText(data.principal), new PublicKey(data.key, data.type)));
-      }).catch(reject);
+      }).catch(e =>  {
+        reject(e);
+      })
     });
   };
   
@@ -51,8 +53,7 @@ export class StoicIdentity extends SignIdentity {
         id.accounts().then(r => {
           resolve(id);          
         }).catch(e => {
-          console.log(e);
-          resolve(false);
+          reject(e);
         });
       };
     });


### PR DESCRIPTION
The two asynchronous methods .connect() & .load() when catching an error should reject the promise instead of resolving to false (as it is currently).

This allows for the possibility of catching those rejections & handling those issues properly to offers a better UX for the set of users that have issues login in (Brave, no cookies, no cross site tracking...).